### PR TITLE
Add permission block for ga

### DIFF
--- a/workflow-templates/docker-build-image.yml
+++ b/workflow-templates/docker-build-image.yml
@@ -26,7 +26,9 @@ env:
 jobs:
 
   build:
-
+    permissions:
+      contents: "read"
+      id-token: "write"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Permissions for read and write for contents and id-token are missing. This PR introduces the permission block. Testen in aig-test repository.