### PR TITLE
Remove preview from docker build and push workflow

### DIFF
--- a/workflow-templates/docker-build-image.properties.json
+++ b/workflow-templates/docker-build-image.properties.json
@@ -1,7 +1,6 @@
 {
     "name": "Docker build and push",
-    "description": "Build a Docker image and push Artifact Registry",
+    "description": "Build a Docker image and push it to Artifact Registry",
     "iconName": "octicon package-dependencies",
-    "categories": ["Continuous integration"],
-    "labels": ["preview"]
+    "categories": ["Continuous integration"]
 }


### PR DESCRIPTION
The "Docker build and push" workflow is added to SSB's starter workflows to efficiently create relativly simple workflows. Building docker image and pushing it to SSB's Artifact Registry is a common case for our users.

The workflow have been tested works as intended 🎉 
This PR will remove the preview label of the workflow, making it publically available. 

Internal ref.[DPSKY-46]

[DPSKY-46]: https://statistics-norway.atlassian.net/browse/DPSKY-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ