### PR TITLE
bump-docker-actions: bump deprecated buildx action

### DIFF
--- a/workflow-templates/docker-build-image.yml
+++ b/workflow-templates/docker-build-image.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Artifact Registry
       uses: docker/login-action@v3


### PR DESCRIPTION
the setup-buildx-action uses a deprecated version of node in v2, bumping to v3 in the template


👀 I can't merge in this repo, so please merge on approve 👀